### PR TITLE
Spec and configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Just use `Model#find` passing in the hashid instead of the model id:
 @person = Person.find(params[:hashid])
 ```
 
+## Configuration
+
+To customize the Hashids seed and ensure that another user of the gem cannot easily reverse engineer your ids, 
+create an initializer and:
+
+```ruby
+Hashid::Rails.configure do |config|
+  config.secret = 'my secret'
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -4,6 +4,17 @@ require 'active_record'
 
 module Hashid
   module Rails
+
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configure
+      self.configuration ||= Configuration.new
+      yield(configuration)
+    end
+
+
     def self.included(base)
       base.extend ClassMethods
     end
@@ -18,8 +29,10 @@ module Hashid
     alias_method :hashid, :to_param
 
     module ClassMethods
+
       def hashids
-        Hashids.new(table_name, 6)
+        secret = Hashid::Rails.configuration ? Hashid::Rails.configuration.secret : ''
+        Hashids.new("#{table_name}#{secret}", 6)
       end
 
       def encode_id(id)
@@ -34,7 +47,17 @@ module Hashid
         super decode_id(hashid) || hashid
       end
     end
+
+    class Configuration
+      attr_accessor :secret
+
+      def initialize
+        @secret = ''
+      end
+
+    end
   end
+
 end
 
 ActiveRecord::Base.send :include, Hashid::Rails

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -1,7 +1,74 @@
 require 'spec_helper'
 
 describe Hashid::Rails do
+
+  subject(:model) { Model.new }
+
   it 'has a version number' do
     expect(Hashid::Rails::VERSION).not_to be nil
   end
+
+  it 'encodes a hashid' do
+    expect(model.encoded_id).to eql '4zKEeJ'
+  end
+
+  it 'decodes a hashid' do
+    expect(Model.decode_id('4zKEeJ')).to eql 1
+  end
+
+  describe 'configure' do
+
+    before(:each) do
+      Hashid::Rails.configure do |config|
+        config.secret = 'my secret'
+      end
+    end
+
+    after(:each) do
+      Hashid::Rails.configure do |config|
+        config.secret = ''
+      end
+    end
+
+    it 'encodes to a different hashid' do
+      expect(model.encoded_id).to eql 'pVNwvq'
+    end
+
+    it 'decodes a hashid' do
+      expect(Model.decode_id('pVNwvq')).to eql 1
+    end
+  end
+
+end
+
+class Model < ActiveRecord::Base
+
+  def self.columns_hash
+    {id: ActiveRecord::ConnectionAdapters::Column.new('id', nil, 'integer', 'integer')}
+  end
+
+  def self.attributes_builder
+    @attributes_builder ||= ActiveRecord::AttributeSet::Builder.new(column_types, columns_hash[:id])
+  end
+
+  def self.columns
+    columns_hash.map {|k,v| v}
+  end
+
+  def self.get_primary_key(base_name)
+    columns_hash[:id]
+  end
+
+  def self.column_types
+    columns_hash
+  end
+
+  def id
+    1
+  end
+
+  def self.connection
+    nil
+  end
+
 end


### PR DESCRIPTION
Addresses Issue #4 

Allows user to configure a secret that is appended to the Hashids salt, so that ids can be truly unique by site.

Also includes specs for the base `encoded_id` and `decode_id` methods as well as the new `Hashid::Rails.configure` method.