### PR TITLE
Fix reload

### DIFF
--- a/hashid-rails.gemspec
+++ b/hashid-rails.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.4.0'
 
   spec.add_runtime_dependency 'activerecord', '~> 4.0'
   spec.add_runtime_dependency 'hashids', '~> 1.0'

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -44,7 +44,7 @@ module Hashid
       end
 
       def find(hashid)
-        return super hashid if caller.select{|s| s =~ /reload/ && s =~ /active_record\/persistence/}.any?
+        return super hashid if caller.first(3).any?{|s| s =~ /active_record\/persistence.*reload/}
         super decode_id(hashid) || hashid
       end
     end

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -44,6 +44,7 @@ module Hashid
       end
 
       def find(hashid)
+        return super hashid if caller.select{|s| s =~ /reload/ && s =~ /active_record\/persistence/}.any?
         super decode_id(hashid) || hashid
       end
     end

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Hashid::Rails do
 
   subject(:model) { Model.new }
-  let(:hashable_id) { model.id }
+  let(:actual_id) { model.id }
 
   it 'has a version number' do
     expect(Hashid::Rails::VERSION).not_to be nil
@@ -14,7 +14,7 @@ describe Hashid::Rails do
   end
 
   it 'decodes a hashid' do
-    expect(Model.decode_id('z3m059')).to eql hashable_id
+    expect(Model.decode_id('z3m059')).to eql actual_id
   end
 
   describe 'configure' do
@@ -36,14 +36,16 @@ describe Hashid::Rails do
     end
 
     it 'decodes a hashid' do
-      expect(Model.decode_id('vGENK4')).to eql hashable_id
+      expect(Model.decode_id('vGENK4')).to eql actual_id
     end
   end
 
   describe '#reload' do
 
+    let(:decoded_id) { Model.decode_id(actual_id) } # 26894362
+
     before do
-      # to find an id that decodes as if it were a valid hashid (brute force)
+      # to find an id that decodes as if it were a valid hashid (by brute force)
       #(10000..100000000).each do |i|
       #  decoded_id = Model.decode_id(i)
       #  raise "#{decoded_id} decodes from real id #{i}" if decoded_id
@@ -51,12 +53,13 @@ describe Hashid::Rails do
     end
 
     it 'prerequesite: real id returns a value from decode_id' do
-      expect(Model.decode_id(hashable_id)).to eql 26894362
+      expect(decoded_id).to_not be_nil
+      expect(Model.decode_id(actual_id)).to eql decoded_id
     end
 
     it 'should use real id' do
       expect_any_instance_of(Model::ActiveRecord_Relation).to receive(:find_with_ids) do |instance, id|
-        expect(id).to eql hashable_id
+        expect(id).to eql actual_id
       end
       expect(subject.reload).to eql subject
     end

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -3,17 +3,18 @@ require 'spec_helper'
 describe Hashid::Rails do
 
   subject(:model) { Model.new }
+  let(:hashable_id) { model.id }
 
   it 'has a version number' do
     expect(Hashid::Rails::VERSION).not_to be nil
   end
 
   it 'encodes a hashid' do
-    expect(model.encoded_id).to eql '4zKEeJ'
+    expect(model.encoded_id).to eql 'z3m059'
   end
 
   it 'decodes a hashid' do
-    expect(Model.decode_id('4zKEeJ')).to eql 1
+    expect(Model.decode_id('z3m059')).to eql hashable_id
   end
 
   describe 'configure' do
@@ -31,12 +32,35 @@ describe Hashid::Rails do
     end
 
     it 'encodes to a different hashid' do
-      expect(model.encoded_id).to eql 'pVNwvq'
+      expect(model.encoded_id).to eql 'vGENK4'
     end
 
     it 'decodes a hashid' do
-      expect(Model.decode_id('pVNwvq')).to eql 1
+      expect(Model.decode_id('vGENK4')).to eql hashable_id
     end
+  end
+
+  describe '#reload' do
+
+    before do
+      # to find an id that decodes as if it were a valid hashid (brute force)
+      #(10000..100000000).each do |i|
+      #  decoded_id = Model.decode_id(i)
+      #  raise "#{decoded_id} decodes from real id #{i}" if decoded_id
+      #end
+    end
+
+    it 'prerequesite: real id returns a value from decode_id' do
+      expect(Model.decode_id(hashable_id)).to eql 26894362
+    end
+
+    it 'should use real id' do
+      expect_any_instance_of(Model::ActiveRecord_Relation).to receive(:find_with_ids) do |instance, id|
+        expect(id).to eql hashable_id
+      end
+      expect(subject.reload).to eql subject
+    end
+
   end
 
 end
@@ -64,11 +88,19 @@ class Model < ActiveRecord::Base
   end
 
   def id
-    1
+    100117
   end
 
   def self.connection
-    nil
+    FakeConnection.new
   end
 
 end
+
+class FakeConnection
+
+  def clear_query_cache
+
+  end
+end
+


### PR DESCRIPTION
Addresses Issue #8 by detecting in `find` when `reload` is a caller. Not the most efficient solution and will not work when a model class overrides reload without calling super. 

This PR also includes #7, as both require new specs. 