### PR TITLE
Require explicitly including Hashid Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Additionally, the `to_param` method is overriden to use hashid instead of id.
 This means methods that take advantage of implicit ID will automatically work
 with hashids.
 
-```ruby
+```erb
 <%= link_to "Model", model %>
 #=> <a href="/models/yLA6m0oM">Model</a>
 ```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ This means methods that take advantage of implicit ID will automatically work
 with hashids.
 
 ```erb
+Passing a hashid model to `link_to`…
 <%= link_to "Model", model %>
-#=> <a href="/models/yLA6m0oM">Model</a>
+
+will use `hashid` instead of `id`.
+<a href="/models/yLA6m0oM">Model</a>
 ```
 
 ## Alternative Usage

--- a/README.md
+++ b/README.md
@@ -32,10 +32,37 @@ $ gem install hashid-rails
 
 ## Basic Usage
 
-Just use `Model#find` passing in the hashid instead of the model id.
+1. Include Hashid Rails in the ActiveRecord model you'd like to enable hashids.
+
+```ruby
+class Model < ActiveRecord::Base
+  include Hashid::Rails
+end
+```
+
+2. Continue using `Model#find` passing in either a hashid or regular 'ol id.
 
 ```ruby
 @person = Person.find(params[:hashid])
+```
+
+## Get hashid of model
+
+You can access the hashid of any model using the `hashid` method.
+
+```ruby
+model = Model.find(params[:hashid])
+model.hashid
+#=> "yLA6m0oM"
+```
+
+Additionally, the `to_param` method is overriden to use hashid instead of id.
+This means methods that take advantage of implicit ID will automatically work
+with hashids.
+
+```ruby
+<%= link_to "Model", model %>
+#=> <a href="/models/yLA6m0oM">Model</a>
 ```
 
 ## Alternative Usage

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -90,5 +90,3 @@ module Hashid
     end
   end
 end
-
-ActiveRecord::Base.send :include, Hashid::Rails

--- a/spec/support/fake_model.rb
+++ b/spec/support/fake_model.rb
@@ -1,4 +1,6 @@
 class FakeModel < ActiveRecord::Base
+  include Hashid::Rails
+
   def self.table_name
     "models"
   end


### PR DESCRIPTION
Stop automatically including Hashid Rails into all models by overriding ActiveRecord::Base. The is easily avoided by using include directly in any ActiveRecord model.