### PR TITLE
Support disabling of hashid signing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Hashid::Rails.configure do |config|
 
   # Whether to override the `find` method
   config.override_find = true
+
+  # Whether to sign hashids to prevent conflicts with regular IDs (see https://github.com/jcypret/hashid-rails/issues/30)
+  config.sign_hashids = true
 end
 ```
 

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -78,13 +78,20 @@ module Hashid
       end
 
       def hashid_encode(id)
-        hashids.encode(HASHID_TOKEN, id)
+        if Hashid::Rails.configuration.sign_hashids
+          hashids.encode(HASHID_TOKEN, id)
+        else
+          hashids.encode(id)
+        end
       end
 
       def hashid_decode(id)
         decoded_hashid = hashids.decode(id.to_s)
-        return id unless valid_hashid?(decoded_hashid)
-        decoded_hashid.last
+        if Hashid::Rails.configuration.sign_hashids
+          valid_hashid?(decoded_hashid) ? decoded_hashid.last : id
+        else
+          decoded_hashid.first
+        end
       end
 
       def valid_hashid?(decoded_hashid)

--- a/lib/hashid/rails/configuration.rb
+++ b/lib/hashid/rails/configuration.rb
@@ -1,7 +1,11 @@
 module Hashid
   module Rails
     class Configuration
-      attr_accessor :salt, :min_hash_length, :alphabet, :override_find
+      attr_accessor :salt,
+                    :min_hash_length,
+                    :alphabet,
+                    :override_find,
+                    :sign_hashids
 
       def initialize
         @salt = ""
@@ -10,6 +14,7 @@ module Hashid
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
                     "1234567890"
         @override_find = true
+        @sign_hashids = true
       end
 
       def for_table(table_name)

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -68,6 +68,17 @@ describe Hashid::Rails do
         expect(encoded_ids).to eq(%w[NPdiEN NwniBe zKwimz])
       end
     end
+
+    context "when hashid signing disabled" do
+      before do
+        Hashid::Rails.configure { |config| config.sign_hashids = false }
+      end
+
+      it "returns unsigned hashid" do
+        encoded_id = FakeModel.encode_id(100_117)
+        expect(encoded_id).to eq("z3m059")
+      end
+    end
   end
 
   describe ".decode_id" do
@@ -104,6 +115,17 @@ describe Hashid::Rails do
       it "returns array of already decoded ids" do
         decoded_ids = FakeModel.decode_id([1, 2, 3])
         expect(decoded_ids).to eq([1, 2, 3])
+      end
+    end
+
+    context "when hashid signing disabled" do
+      before do
+        Hashid::Rails.configure { |config| config.sign_hashids = false }
+      end
+
+      it "returns decoded unsigned hashid" do
+        decoded_id = FakeModel.decode_id("z3m059")
+        expect(decoded_id).to eq(100_117)
       end
     end
   end
@@ -281,6 +303,7 @@ describe Hashid::Rails do
         expect(config.alphabet).to eq(
           "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
         expect(config.override_find).to eq(true)
+        expect(config.sign_hashids).to eq(true)
       end
 
       Hashid::Rails.configure do |configuration|
@@ -288,6 +311,7 @@ describe Hashid::Rails do
         configuration.min_hash_length = 13
         configuration.alphabet = "ABC"
         configuration.override_find = false
+        configuration.sign_hashids = false
       end
 
       aggregate_failures "after config" do
@@ -295,6 +319,7 @@ describe Hashid::Rails do
         expect(config.min_hash_length).to eq(13)
         expect(config.alphabet).to eq("ABC")
         expect(config.override_find).to eq(false)
+        expect(config.sign_hashids).to eq(false)
       end
     end
   end


### PR DESCRIPTION
This PR fixes https://github.com/jcypret/hashid-rails/issues/30 by implementing a configuration option, `sign_hashids`, which controls how the underlying hashid is generated. The choice is:

### sign_hashids = true (default)
- hashid is generated by encoding a "signed" array; `encode_id([42, id])`.
- this logic was implemented in https://github.com/jcypret/hashid-rails/commit/941bc3e5e052639e4f8fe29347b48c8069c55edb.
- this signed array is validated during decoding, to identify that the correct ID has been obtained (i.e. when decoding, we confirm that the decoded value is of the form `[42, x]` and return the `x`.
- the benefit is that when decoding a value which could be either a raw ID or a hashid, it's possible to determine which it is; a raw ID that may (by chance) be a valid hashid (for a different ID) will not be mistakenly decoded into that ID.
- the disadvantage is a slightly longer hashid being generated.

### sign_hashids = false
- hashid is generated simply from the id itself; `encode_id(id)`.
- this was the behaviour for `hashid-rails < 1.0.0`; in order to maintain backwards compatibility for existing hashids, this must be set.