### PR TITLE
Include finder methods on associations

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -34,6 +34,16 @@ module Hashid
     alias to_param hashid
 
     module ClassMethods
+      def relation
+        super.tap { |r| r.extend ClassMethods }
+      end
+
+      def has_many(*args, &block)
+        options = args.extract_options!
+        options[:extend] = Array(options[:extend]).push(ClassMethods)
+        super(*args, options, &block)
+      end
+
       def encode_id(ids)
         if ids.is_a?(Array)
           ids.map { |id| hashid_encode(id) }

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -38,7 +38,7 @@ module Hashid
         super.tap { |r| r.extend ClassMethods }
       end
 
-      def has_many(*args, &block)
+      def has_many(*args, &block) # rubocop:disable Style/PredicateName
         options = args.extract_options!
         options[:extend] = Array(options[:extend]).push(ClassMethods)
         super(*args, options, &block)

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -45,6 +45,24 @@ describe Hashid::Rails do
 
       expect(comment.post_id).to eq(post.id)
     end
+
+    it "works with eager loading" do
+      post = Post.create!
+      Comment.create!(post: post)
+
+      result = Post.includes(:comments).find(post.hashid)
+
+      expect(result).to eq(post)
+    end
+
+    it "finds association through parent" do
+      post = Post.create!
+      comment = Comment.create!(post: post)
+
+      result = Post.find(post.hashid).comments.find(comment.hashid)
+
+      expect(result).to eq(comment)
+    end
   end
 
   describe ".encode_id" do


### PR DESCRIPTION
Enabled the find methods to work when calling through associations such `post.comments.find()` or `post.includes(:comments).find()`.