### PR TITLE
Remove shell install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ And then execute:
 $ bundle
 ```
 
-Or install it yourself as:
-
-```shell
-$ gem install hashid-rails -v 1.0
-```
-
 ## Basic Usage
 
 1. Include Hashid Rails in the ActiveRecord model you'd like to enable hashids.


### PR DESCRIPTION
These are not relevant as a rails context is required to get value out of this gem.