### PR TITLE
Add fallback value for unsigned hashids

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -105,7 +105,7 @@ module Hashid
         if Hashid::Rails.configuration.sign_hashids
           valid_hashid?(decoded_hashid) ? decoded_hashid.last : fallback_value
         else
-          decoded_hashid.first
+          decoded_hashid.first || fallback_value
         end
       end
 

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -350,7 +350,6 @@ describe Hashid::Rails do
     end
   end
 
-
   describe ".configure" do
     it "sets gem configuration with block" do
       config = Hashid::Rails.configuration
@@ -359,7 +358,8 @@ describe Hashid::Rails do
         expect(config.salt).to eq("")
         expect(config.min_hash_length).to eq(6)
         expect(config.alphabet).to eq(
-          "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+          "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        )
         expect(config.override_find).to eq(true)
         expect(config.sign_hashids).to eq(true)
       end

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -163,190 +163,193 @@ describe Hashid::Rails do
     end
   end
 
-  shared_examples_for "find" do
-    context "when finding single model" do
-      it "returns correct model by hashid" do
-        model = FakeModel.create!
+  shared_examples_for "finders" do
+    describe ".find" do
+      context "when finding single model" do
+        it "returns correct model by hashid" do
+          model = FakeModel.create!
 
-        result = FakeModel.find(model.hashid)
+          result = FakeModel.find(model.hashid)
 
-        expect(result).to eq(model)
-      end
-
-      it "returns correct model by id" do
-        model = FakeModel.create!
-
-        result = FakeModel.find(model.id)
-
-        expect(result).to eq(model)
-      end
-    end
-
-    context "when single id as array" do
-      it "returns array with correct model by hashid" do
-        model = FakeModel.create!
-
-        result = FakeModel.find([model.hashid])
-
-        expect(result).to eq([model])
-      end
-
-      it "returns array with correct model by id" do
-        model = FakeModel.create!
-
-        result = FakeModel.find([model.id])
-
-        expect(result).to eq([model])
-      end
-    end
-
-    context "when multiple ids as args" do
-      it "returns array of correct models by hashids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find(model1.hashid, model2.hashid)
-
-        expect(result).to eq([model1, model2])
-      end
-
-      it "returns array of correct models by ids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find(model1.id, model2.id)
-
-        expect(result).to eq([model1, model2])
-      end
-
-      it "returns array of correct models by mix of hashids and ids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find(model1.hashid, model2.id)
-
-        expect(result).to eq([model1, model2])
-      end
-    end
-
-    context "when multiple ids as an array" do
-      it "returns array of correct models by hashids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find([model1.hashid, model2.hashid])
-
-        expect(result).to eq([model1, model2])
-      end
-
-      it "returns array of correct models by ids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find([model1.id, model2.id])
-
-        expect(result).to eq([model1, model2])
-      end
-
-      it "returns array of correct models by mix of hashids and ids" do
-        model1 = FakeModel.create!
-        model2 = FakeModel.create!
-
-        result = FakeModel.find([model1.hashid, model2.id])
-
-        expect(result).to eq([model1, model2])
-      end
-    end
-
-    context "when find is disabled" do
-      it "does not decode id" do
-        model = FakeModel.create!
-
-        Hashid::Rails.configure do |config|
-          config.override_find = true
-        end
-        result = FakeModel.find(model.hashid)
-
-        expect(result).to eq(model)
-
-        Hashid::Rails.configure do |config|
-          config.override_find = false
+          expect(result).to eq(model)
         end
 
-        expect { FakeModel.find(model.hashid) }
+        it "returns correct model by id" do
+          model = FakeModel.create!
+
+          result = FakeModel.find(model.id)
+
+          expect(result).to eq(model)
+        end
+      end
+
+      context "when single id as array" do
+        it "returns array with correct model by hashid" do
+          model = FakeModel.create!
+
+          result = FakeModel.find([model.hashid])
+
+          expect(result).to eq([model])
+        end
+
+        it "returns array with correct model by id" do
+          model = FakeModel.create!
+
+          result = FakeModel.find([model.id])
+
+          expect(result).to eq([model])
+        end
+      end
+
+      context "when multiple ids as args" do
+        it "returns array of correct models by hashids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find(model1.hashid, model2.hashid)
+
+          expect(result).to eq([model1, model2])
+        end
+
+        it "returns array of correct models by ids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find(model1.id, model2.id)
+
+          expect(result).to eq([model1, model2])
+        end
+
+        it "returns array of correct models by mix of hashids and ids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find(model1.hashid, model2.id)
+
+          expect(result).to eq([model1, model2])
+        end
+      end
+
+      context "when multiple ids as an array" do
+        it "returns array of correct models by hashids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find([model1.hashid, model2.hashid])
+
+          expect(result).to eq([model1, model2])
+        end
+
+        it "returns array of correct models by ids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find([model1.id, model2.id])
+
+          expect(result).to eq([model1, model2])
+        end
+
+        it "returns array of correct models by mix of hashids and ids" do
+          model1 = FakeModel.create!
+          model2 = FakeModel.create!
+
+          result = FakeModel.find([model1.hashid, model2.id])
+
+          expect(result).to eq([model1, model2])
+        end
+      end
+
+      context "when find is disabled" do
+        it "does not decode id" do
+          model = FakeModel.create!
+
+          Hashid::Rails.configure do |config|
+            config.override_find = true
+          end
+          result = FakeModel.find(model.hashid)
+
+          expect(result).to eq(model)
+
+          Hashid::Rails.configure do |config|
+            config.override_find = false
+          end
+
+          expect { FakeModel.find(model.hashid) }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "does not call decode_id" do
+          model = FakeModel.create!
+          Hashid::Rails.configure do |config|
+            config.override_find = false
+          end
+
+          expect(FakeModel).not_to receive(:decode_id).with(model.id)
+
+          FakeModel.find(model.id)
+        end
+      end
+    end
+
+    describe ".find_by_hashid" do
+      it "finds model by hashid" do
+        model = FakeModel.create!
+
+        result = FakeModel.find_by_hashid(model.hashid)
+
+        expect(result).to eq(model)
+      end
+
+      it "returns nil when unable to find model" do
+        result = FakeModel.find_by_hashid("ABC")
+
+        expect(result).to eq(nil)
+      end
+
+      it "returns nil for non-hashid" do
+        model = FakeModel.create!
+
+        result = FakeModel.find_by_hashid(model.id)
+
+        expect(result).to eq(nil)
+      end
+    end
+
+    describe ".find_by_hashid!" do
+      it "finds model by hashid" do
+        model = FakeModel.create!
+
+        result = FakeModel.find_by_hashid!(model.hashid)
+
+        expect(result).to eq(model)
+      end
+
+      it "raises record not found when unable to find model" do
+        expect { FakeModel.find_by_hashid!("ABC") }
           .to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "does not call decode_id" do
+      it "raises record not found for non-hashid" do
         model = FakeModel.create!
-        Hashid::Rails.configure do |config|
-          config.override_find = false
-        end
 
-        expect(FakeModel).not_to receive(:decode_id).with(model.id)
-
-        FakeModel.find(model.id)
+        expect { FakeModel.find_by_hashid!(model.id) }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
-  describe ".find" do
-    it_behaves_like("find")
+  describe "finders" do
+    context "when signed hashids" do
+      before { Hashid::Rails.configuration.sign_hashids = true }
+      it_behaves_like("finders")
+    end
 
-    context "when hashid signing is disabled" do
-      before do
-        Hashid::Rails.configure { |config| config.sign_hashids = false }
-      end
-
-      it_behaves_like("find")
+    context "when unsigned hashids" do
+      before { Hashid::Rails.configuration.sign_hashids = false }
+      it_behaves_like("finders")
     end
   end
 
-  describe ".find_by_hashid" do
-    it "finds model by hashid" do
-      model = FakeModel.create!
-
-      result = FakeModel.find_by_hashid(model.hashid)
-
-      expect(result).to eq(model)
-    end
-
-    it "returns nil when unable to find model" do
-      result = FakeModel.find_by_hashid("ABC")
-
-      expect(result).to eq(nil)
-    end
-
-    it "returns nil for non-hashid" do
-      model = FakeModel.create!
-
-      result = FakeModel.find_by_hashid(model.id)
-
-      expect(result).to eq(nil)
-    end
-  end
-
-  describe ".find_by_hashid!" do
-    it "finds model by hashid" do
-      model = FakeModel.create!
-
-      result = FakeModel.find_by_hashid!(model.hashid)
-
-      expect(result).to eq(model)
-    end
-
-    it "raises record not found when unable to find model" do
-      expect { FakeModel.find_by_hashid!("ABC") }
-        .to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "raises record not found for non-hashid" do
-      model = FakeModel.create!
-
-      expect { FakeModel.find_by_hashid!(model.id) }
-        .to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
 
   describe ".configure" do
     it "sets gem configuration with block" do

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -163,7 +163,7 @@ describe Hashid::Rails do
     end
   end
 
-  describe ".find" do
+  shared_examples_for "find" do
     context "when finding single model" do
       it "returns correct model by hashid" do
         model = FakeModel.create!
@@ -288,37 +288,17 @@ describe Hashid::Rails do
         FakeModel.find(model.id)
       end
     end
+  end
+
+  describe ".find" do
+    it_behaves_like("find")
 
     context "when hashid signing is disabled" do
       before do
         Hashid::Rails.configure { |config| config.sign_hashids = false }
       end
 
-      it "finds by hashid" do
-        model = FakeModel.create!
-
-        result = FakeModel.find(model.hashid)
-
-        expect(result).to eq(model)
-      end
-
-      it "finds by id" do
-        model = FakeModel.create!
-
-        result = FakeModel.find(model.id)
-
-        expect(result).to eq(model)
-      end
-
-      it "raises record not found when unknown hashid" do
-        expect { FakeModel.find("ABC") }
-          .to raise_error(ActiveRecord::RecordNotFound)
-      end
-
-      it "raises record not found when unknown id" do
-        expect { FakeModel.find(123) }
-          .to raise_error(ActiveRecord::RecordNotFound)
-      end
+      it_behaves_like("find")
     end
   end
 

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -288,6 +288,38 @@ describe Hashid::Rails do
         FakeModel.find(model.id)
       end
     end
+
+    context "when hashid signing is disabled" do
+      before do
+        Hashid::Rails.configure { |config| config.sign_hashids = false }
+      end
+
+      it "finds by hashid" do
+        model = FakeModel.create!
+
+        result = FakeModel.find(model.hashid)
+
+        expect(result).to eq(model)
+      end
+
+      it "finds by id" do
+        model = FakeModel.create!
+
+        result = FakeModel.find(model.id)
+
+        expect(result).to eq(model)
+      end
+
+      it "raises record not found when unknown hashid" do
+        expect { FakeModel.find("ABC") }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises record not found when unknown id" do
+        expect { FakeModel.find(123) }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe ".find_by_hashid" do


### PR DESCRIPTION
This PR fixes an issue identified here: https://github.com/jcypret/hashid-rails/issues/45.

The `.find` for unsigned hashids is not currently falling back to the default value. This PR fixes that by extended the test suite to exercise the same `find` and `find_by_hashid` tests across both the signed and unsigned models. This shows the test failure which is then fixed by adding a fallback.