### PR TITLE
Created a hash decoder for hashed ids within Rails params.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 /.ruby-version
+/.idea
+/.tm_properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.2 (2018-03-30)
+- Added ability to decode hashids within Rails inbound parameter hashes.
+
 ## 1.2.1 (2018-01-13)
 - Found issue where unsigned hashids with `find` did not fall back to passed in ID ([#46](https://github.com/jcypret/hashid-rails/pull/46)).
 - Move finder specs to a shared example run against both the signed and unsigned hashids.

--- a/hashid-rails.gemspec
+++ b/hashid-rails.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hashid/rails/version"
 

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "hashid/rails/version"
 require "hashid/rails/configuration"
+require "hashid/rails/decoder"
 require "hashids"
 require "active_record"
 

--- a/lib/hashid/rails/decoder.rb
+++ b/lib/hashid/rails/decoder.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "hashid/rails/parameter_patterns"
+
+module Hashid
+  module Rails
+    class Decoder
+      class << self
+        include ParameterPatterns
+
+        def decode_params(parent_class, params)
+          _decode_params(parent_class, params)
+        end
+
+        private
+
+        def _decode_params(parent_class, params, child_name = nil)
+          dup = HashWithIndifferentAccess.new(params.dup)
+          dup.update(dup) do |k, v|
+            if requires_decoding?(k)
+              decode(parent_class, k, v, child_name)
+            else
+              v
+            end
+          end
+        end
+
+        def requires_decoding?(key)
+          id?(key) ||
+            association?(key) ||
+            associations?(key) ||
+            nested_association?(key) ||
+            nested_associations?(key)
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def decode(parent_class, key, value, child_name)
+          if id?(key)
+            decode_id(parent_class, value)
+          elsif association?(key)
+            decode_association(parent_class, key, value)
+          elsif associations?(key)
+            decode_associations(parent_class, key, value)
+          elsif nested_association?(key)
+            decode_nested_association(parent_class, value, child_name)
+          elsif nested_associations?(key)
+            decode_nested_associations(parent_class, key, value)
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def decode_id(parent_class, hashid)
+          parent_class.decode_id(hashid, fallback: true)
+        rescue NoMethodError
+          hashid
+        end
+
+        def decode_child_id(parent_class, hashid, child_name)
+          association = parent_class.reflect_on_association(child_name)
+          return hashid if association.nil?
+          decode_id(association.klass, hashid)
+        end
+
+        def decode_child_ids(parent_class, hashids, child_name)
+          hashids.map do |hashid|
+            decode_child_id(parent_class, hashid, child_name)
+          end
+        end
+
+        def decode_association(parent_class, key, value)
+          child_name = key.to_s.gsub("_id", "")
+          decode_child_id(parent_class, value, child_name)
+        end
+
+        def decode_associations(parent_class, key, value)
+          child_name = key.to_s.gsub("_ids", "s")
+          decode_child_ids(parent_class, value, child_name)
+        end
+
+        def decode_nested_association(parent_class, value, child_name)
+          association = parent_class.reflect_on_association(child_name)
+          child_class = association.klass
+          _decode_params(child_class, value)
+        end
+
+        def decode_nested_associations(parent_class, key, value)
+          child_name = key.to_s.gsub("_attributes", "")
+          _decode_params(parent_class, value, child_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/hashid/rails/parameter_patterns.rb
+++ b/lib/hashid/rails/parameter_patterns.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Hashid
+  module Rails
+    module ParameterPatterns
+      def id?(key)
+        key.match?(/^id$/)
+      end
+
+      def association?(key)
+        key.match?(/_id$/)
+      end
+
+      def associations?(key)
+        key.match?(/_ids$/)
+      end
+
+      def nested_association?(key)
+        key.match?(/^[0-9]+$/)
+      end
+
+      def nested_associations?(key)
+        key.match?(/_attributes$/)
+      end
+    end
+  end
+end

--- a/lib/hashid/rails/version.rb
+++ b/lib/hashid/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Hashid
   module Rails
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/spec/hashid/rails/decoder_spec.rb
+++ b/spec/hashid/rails/decoder_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Hashid::Rails::Decoder do
+  describe "#decode_params" do
+    let(:post) { Post.new(id: 1) }
+    let(:image) { Image.new(id: 1) }
+    let(:author) { Author.new(id: 1) }
+    let(:another_author) { Author.new(id: 2) }
+    let(:topic_one) { Topic.new(id: 1) }
+    let(:topic_two) { Topic.new(id: 2) }
+    let(:comment_one) { Comment.new(id: 1) }
+    let(:comment_two) { Comment.new(id: 2) }
+    let(:sponsor_id) { "acme-rockets-01" }
+    let(:post_params) do
+      {
+        id: post.to_param,
+        title: "Title"
+      }
+    end
+    let(:author_params) do
+      {
+        author_id: author.to_param
+      }
+    end
+    let(:topic_params) do
+      {
+        topic_ids: [
+          topic_one.to_param,
+          topic_two.to_param
+        ]
+      }
+    end
+    let(:comments_params) do
+      {
+        comments_attributes: {
+          "0" => {
+            id: comment_one.to_param
+          },
+          "1" => {
+            id: comment_two.to_param
+          }
+        }
+      }
+    end
+    let(:image_params) do
+      {
+        image_id: image.to_param
+      }
+    end
+    let(:sponsor_params) do
+      {
+        sponsor_id: sponsor_id
+      }
+    end
+
+    it "decodes id and nothing else" do
+      actual = Hashid::Rails::Decoder.decode_params(Post, post_params)
+      expect(actual[:id]).to eq(post.id)
+      expect(actual[:title]).to eq("Title")
+    end
+
+    it "decodes belongs_to association" do
+      params = post_params.merge(author_params)
+      actual = Hashid::Rails::Decoder.decode_params(Post, params)
+      expect(actual[:author_id]).to eq(author.id)
+    end
+
+    it "decodes has_many association" do
+      params = post_params.merge(comments_params)
+      actual = Hashid::Rails::Decoder.decode_params(Post, params)
+      expect(actual[:comments_attributes]["0"][:id]).to eq(comment_one.id)
+      expect(actual[:comments_attributes]["1"][:id]).to eq(comment_two.id)
+    end
+
+    it "decodes has_and_belongs_to_many association" do
+      params = post_params.merge(topic_params)
+      actual = Hashid::Rails::Decoder.decode_params(Post, params)
+      expect(actual[:topic_ids][0]).to eq(topic_one.id)
+      expect(actual[:topic_ids][1]).to eq(topic_two.id)
+    end
+
+    it "passes over un-hashed ids" do
+      actual = Hashid::Rails::Decoder.decode_params(Post, id: post.id)
+      expect(actual[:id]).to eq(post.id)
+    end
+
+    it "handles when hashid not enabled" do
+      params = post_params.merge(image_params)
+      actual = Hashid::Rails::Decoder.decode_params(Post, params)
+      expect(actual[:image_id]).to eq(image.id.to_s)
+    end
+
+    it "handles params that look like associations but aren't" do
+      params = post_params.merge(sponsor_params)
+      actual = Hashid::Rails::Decoder.decode_params(Post, params)
+      expect(actual[:sponsor_id]).to eq(sponsor_id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,14 @@ SimpleCov.start
 
 require "byebug"
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("lib", __dir__)
 require "hashid/rails"
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
 require_relative "support/schema"
 require_relative "support/fake_model"
+require_relative "support/author"
 require_relative "support/post"
+require_relative "support/image"
 require_relative "support/comment"
+require_relative "support/topic"

--- a/spec/support/author.rb
+++ b/spec/support/author.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Author < ActiveRecord::Base
+  include Hashid::Rails
+
+  has_many :posts
+end

--- a/spec/support/image.rb
+++ b/spec/support/image.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Image < ActiveRecord::Base
+  belongs_to :post
+end

--- a/spec/support/post.rb
+++ b/spec/support/post.rb
@@ -3,5 +3,8 @@
 class Post < ActiveRecord::Base
   include Hashid::Rails
 
+  has_one :image
+  belongs_to :author
   has_many :comments
+  has_and_belongs_to_many :topics
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -7,8 +7,21 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
-  create_table :posts, force: true
+  create_table :authors, force: true
+  create_table :posts, force: true do |t|
+    t.belongs_to :author, index: true
+    t.string :title
+    t.integer :sponsor_id
+  end
+  create_table :images, force: true do |t|
+    t.belongs_to :post, index: true
+  end
   create_table :comments, force: true do |t|
     t.belongs_to :post, index: true
+  end
+  create_table :topics, force: true
+  create_table :posts_topics, id: false, force: true do |t|
+    t.integer :post_id
+    t.integer :topic_id
   end
 end

--- a/spec/support/topic.rb
+++ b/spec/support/topic.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Topic < ActiveRecord::Base
+  include Hashid::Rails
+
+  has_and_belongs_to_many :posts, join_table: :posts_topics
+end


### PR DESCRIPTION
Hi Folks

I've created a class that decodes ids for inbound Rails param hashes. You use it like this...

```
class PostsController < ApplicationController
  ...
  def post_params
    p = params.require(:post).permit(...)
    Hashid::Rails::Decoder.decode_params(Post, p)
  end
end
```

So, in addition to having urls like `https://www.example.com/posts/e45Frd` behaving like `https://www.example.com/posts/12345` with this change you now also get your inbound hashids contained within form params converted to their real ids as well. 

I'm quite surprised that something like this does not already exist within any id obfuscating gem I've tried, so a part of me thinks I'm perhaps missing something and there really is no need for any of this code? Or perhaps no-one is obfuscating ids within form params? No idea. 

At any rate, this code is text driven, 100% covered, and complies with your Rubocop rules (except for one method Hashid::Rails::Decoder#decode that I tried splitting up but decided to leave for clarity). 

I also fixed up a few existing minor Rubocop failures. 

You'll see I've had to make the schema a little more complicated owing to the fact I needed to demonstrate different object association types. I think it remains pretty clear though. 