### PR TITLE
Switch code coverage reporting to use CC binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=37aee70bb2e818f3bf4d2af88ea4a4355393901ba98b3876c244d42ed20fdbe1
 language: ruby
 cache: bundler
 rvm:
   - 2.3.0
-addons:
-  code_climate:
-    repo_token: 37aee70bb2e818f3bf4d2af88ea4a4355393901ba98b3876c244d42ed20fdbe1
-after_success:
-  - bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/hashid-rails.gemspec
+++ b/hashid-rails.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "sqlite3"
 
   spec.add_runtime_dependency "activerecord", ">= 4.0"


### PR DESCRIPTION
The Code Climate test reporter is now deprecated in favor of a binary. I
removed the reporter dependency, added simplecov as a dev dependency to
continue running locally, and updated the Travis config to run the
binary during CI.