### PR TITLE
Fix fallback in case of letters-only alphabet

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -101,14 +101,16 @@ module Hashid
       end
 
       def hashid_decode(id, fallback:)
-        decoded_hashid = hashids.decode(id.to_s)
         fallback_value = fallback ? id : nil
+        decoded_hashid = hashids.decode(id.to_s)
 
         if Hashid::Rails.configuration.sign_hashids
           valid_hashid?(decoded_hashid) ? decoded_hashid.last : fallback_value
         else
           decoded_hashid.first || fallback_value
         end
+      rescue Hashids::InputError
+        fallback_value
       end
 
       def valid_hashid?(decoded_hashid)

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -163,6 +163,22 @@ describe Hashid::Rails do
         expect(decoded_id).to eq(100_117)
       end
     end
+
+    context "with letters-only alphabet" do
+      before do
+        Hashid::Rails.configure { |config| config.alphabet = [*"A".."Z"].join }
+      end
+
+      it "returns nil when already decoded id" do
+        decoded_id = FakeModel.decode_id(100_117, fallback: false)
+        expect(decoded_id).to eq(nil)
+      end
+
+      it "returns already decoded id when fallback" do
+        decoded_id = FakeModel.decode_id(100_117, fallback: true)
+        expect(decoded_id).to eq(100_117)
+      end
+    end
   end
 
   shared_examples_for "finders" do


### PR DESCRIPTION
Hi!

When I run this gem with a letters-only alphabet (and `config.override_find = true`),  `MyModel.find(123)` raises a Hashids::InputError exception when it tries to decode non-alphabet symbols.