### PR TITLE
Added failing test for finds association through non-hashid parent

### DIFF
--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -65,6 +65,15 @@ describe Hashid::Rails do
 
       expect(result).to eq(comment)
     end
+
+    it "finds association through non-hashid parent" do
+      post = OtherPost.create!
+      comment = post.comments.create!
+
+      result = post.comments.find(comment.hashid)
+
+      expect(result).to eq(comment)
+    end
   end
 
   describe ".encode_id" do

--- a/spec/support/post.rb
+++ b/spec/support/post.rb
@@ -5,3 +5,8 @@ class Post < ActiveRecord::Base
 
   has_many :comments
 end
+
+class OtherPost < ActiveRecord::Base
+  self.table_name = "posts"
+  has_many :comments, foreign_key: "post_id"
+end


### PR DESCRIPTION
Hey, thanks for this awesome library 💯 

If you have a `has_many` association where the parent does not use hashids, `find` through the association doesn't return the associated record. I added a failing test case to demonstrate.