### PR TITLE
Adds mechanism to allow custom token source

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -93,8 +93,8 @@ module Hashid
       end
 
       def hashid_encode(id)
-        if Hashid::Rails.configuration.sign_hashids
-          hashids.encode(HASHID_TOKEN, id)
+        if (sig = Hashid::Rails.configuration.sign_hashids)
+          hashids.encode(signature(sig), id)
         else
           hashids.encode(id)
         end
@@ -114,7 +114,11 @@ module Hashid
       end
 
       def valid_hashid?(decoded_hashid)
-        decoded_hashid.size == 2 && decoded_hashid.first == HASHID_TOKEN
+        decoded_hashid.size == 2 && decoded_hashid.first == signature
+      end
+
+      def signature(sig = Hashid::Rails.configuration.sign_hashids)
+        sig.is_a?(Symbol) && respond_to?(sig) ? send(sig) : HASHID_TOKEN
       end
     end
   end


### PR DESCRIPTION
This would allow a person to designate a method on the class/ActiveRecord model that could be used for token signing with the `HASHID_TOKEN` being the default fallback if the method doesn't exist