### PR TITLE
encode nil IDs as nil

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -93,6 +93,8 @@ module Hashid
       end
 
       def hashid_encode(id)
+        return nil if id.nil?
+
         if Hashid::Rails.configuration.sign_hashids
           hashids.encode(HASHID_TOKEN, id)
         else

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -17,6 +17,11 @@ describe Hashid::Rails do
       model = FakeModel.new(id: 100_117)
       expect(model.hashid).to eq(model.to_param)
     end
+
+    it "is nil when the model id is nil" do
+      model = FakeModel.new
+      expect(model.hashid).to be_nil
+    end
   end
 
   describe "#reload" do
@@ -68,6 +73,13 @@ describe Hashid::Rails do
   end
 
   describe ".encode_id" do
+    context "when nil" do
+      it "returns nil" do
+        encoded_id = FakeModel.encode_id(nil)
+        expect(encoded_id).to be_nil
+      end
+    end
+
     context "when single id" do
       it "returns hashid" do
         encoded_id = FakeModel.encode_id(100_117)


### PR DESCRIPTION
In "normal" Rails, the `id` (and hence the value of `#to_param`) is nil
for records that have not yet been persisted.

Previously, including the `Hashid::Rails` concern broke this behaviour,
raising an exception when `Model.new.to_param` was called. (Cases where
you might want to get the ID of a new model include serializing it over
a JSON API where the "edit" endpoint returns a new model instance if
one does not already exist.)

This change handles the above case by checking for nil in
`model.hashid_encode`.