### PR TITLE
Setup CI to run with GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,24 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install Ruby (2.6)
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Install SQLite
+      run: sudo apt install -y libsqlite3-dev
+
+    - name: Build and test with RSpec
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hashid Rails
 [![Gem Version](https://badge.fury.io/rb/hashid-rails.svg)](https://badge.fury.io/rb/hashid-rails)
-[![Build Status](https://travis-ci.com/jcypret/hashid-rails.svg?branch=master)](https://travis-ci.org/jcypret/hashid-rails)
+![Build Status](https://github.com/jcypret/hashid-rails/workflows/build/badge.svg?branch=master)
 [![Code Climate](https://codeclimate.com/github/jcypret/hashid-rails/badges/gpa.svg)](https://codeclimate.com/github/jcypret/hashid-rails)
 [![Test Coverage](https://codeclimate.com/github/jcypret/hashid-rails/badges/coverage.svg)](https://codeclimate.com/github/jcypret/hashid-rails/coverage)
 


### PR DESCRIPTION
Swap out repo to run CI on the GitHub platform using GitHub Actions
rather than Travis CI. This eliminates a dependency. Also updates the
main repo build badge.