### PR TITLE
Add code climate coverage via GH Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -17,8 +17,19 @@ jobs:
     - name: Install SQLite
       run: sudo apt install -y libsqlite3-dev
 
+    - name: Setup Code Climate test-reporter
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+        ./cc-test-reporter before-build
+
     - name: Build and test with RSpec
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rspec
+
+    - name: Publish code coverage
+      run: |
+        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+        ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
The code climate integration previously went through Travis CI. This sets up the reporter before the test run, then publishes the results in a step following the test run. We also need to parse out the branch name so that Code Climate can attribute it correctly.