### PR TITLE
Add support for model-level config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0 (2019-10-29)
+- Add support for model-level config ([#67](https://github.com/jcypret/hashid-rails/pull/67))
+
 ## 1.2.2 (2018-07-29)
 ### Fixed
 - Handle exception raised when using a letter-only alphabet and attempting to

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ model.hashid
 #=> "yLA6m0oM"
 ```
 
-Additionally, the `to_param` method is overriden to use hashid instead of id.
+Additionally, the `to_param` method is overridden to use hashid instead of id.
 This means methods that take advantage of implicit ID will automatically work
 with hashids.
 
@@ -94,8 +94,9 @@ default options.
 
 ```ruby
 Hashid::Rails.configure do |config|
-  # The salt to use for generating hashid. Prepended with table name.
+  # The salt to use for generating hashid. Prepended with pepper (table name).
   config.salt = ""
+  config.pepper = table_name
 
   # The minimum length of generated hashids
   config.min_hash_length = 6
@@ -110,6 +111,22 @@ Hashid::Rails.configure do |config|
 
   # Whether to sign hashids to prevent conflicts with regular IDs (see https://github.com/jcypret/hashid-rails/issues/30)
   config.sign_hashids = true
+end
+```
+
+### Model-Level Config
+
+You can also customize the hashid configuration at the model level.
+`hashid_config` supports all the same options as the `Hashid::Rails.configure`
+block and allows for each model to have a different config. This can be useful
+for setting a custom salt/pepper. For instance, the pepper defaults to the table
+name, so if you rename the table, you can keep the same hashids by setting the
+pepper to the old table name.
+
+```ruby
+class Model < ActiveRecord::Base
+  include Hashid::Rails
+  hashid_config pepper: "old_table_name"
 end
 ```
 

--- a/lib/hashid/rails/configuration.rb
+++ b/lib/hashid/rails/configuration.rb
@@ -4,6 +4,7 @@ module Hashid
   module Rails
     class Configuration
       attr_accessor :salt,
+                    :pepper,
                     :min_hash_length,
                     :alphabet,
                     :override_find,
@@ -11,6 +12,7 @@ module Hashid
 
       def initialize
         @salt = ""
+        @pepper = ""
         @min_hash_length = 6
         @alphabet = "abcdefghijklmnopqrstuvwxyz" \
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
@@ -19,8 +21,8 @@ module Hashid
         @sign_hashids = true
       end
 
-      def for_table(table_name)
-        ["#{table_name}#{salt}", min_hash_length, alphabet]
+      def to_args
+        ["#{pepper}#{salt}", min_hash_length, alphabet]
       end
     end
   end

--- a/lib/hashid/rails/version.rb
+++ b/lib/hashid/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Hashid
   module Rails
-    VERSION = "1.2.2"
+    VERSION = "1.3.0"
   end
 end

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -3,7 +3,12 @@
 require "spec_helper"
 
 describe Hashid::Rails do
-  before(:each) { Hashid::Rails.reset }
+  before(:each) do
+    Hashid::Rails.reset
+    FakeModel.reset_hashid_config
+    Post.reset_hashid_config
+    Comment.reset_hashid_config
+  end
 
   describe "#hashid" do
     it "returns model ID encoded as hashid" do
@@ -284,13 +289,15 @@ describe Hashid::Rails do
           Hashid::Rails.configure do |config|
             config.override_find = true
           end
-          result = FakeModel.find(model.hashid)
+          FakeModel.reset_hashid_config
 
+          result = FakeModel.find(model.hashid)
           expect(result).to eq(model)
 
           Hashid::Rails.configure do |config|
             config.override_find = false
           end
+          FakeModel.reset_hashid_config
 
           expect { FakeModel.find(model.hashid) }
             .to raise_error(ActiveRecord::RecordNotFound)
@@ -397,6 +404,65 @@ describe Hashid::Rails do
         expect(config.override_find).to eq(false)
         expect(config.sign_hashids).to eq(false)
       end
+    end
+
+    it "inherits default configuration" do
+      config = FakeModel.hashid_configuration
+
+      aggregate_failures "default config" do
+        expect(config.salt).to eq("")
+        expect(config.pepper).to eq(FakeModel.table_name)
+        expect(config.min_hash_length).to eq(6)
+        expect(config.alphabet).to eq(
+          "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        )
+        expect(config.override_find).to eq(true)
+        expect(config.sign_hashids).to eq(true)
+      end
+    end
+
+    it "supports model-specific config" do
+      FakeModel.hashid_config(
+        salt: "shhh",
+        pepper: "achoo",
+        min_hash_length: 7,
+        alphabet: "XYZ",
+        override_find: false,
+        sign_hashids: false
+      )
+
+      # model-level has new config
+      config = FakeModel.hashid_configuration
+      aggregate_failures "model-level config" do
+        expect(config.salt).to eq("shhh")
+        expect(config.pepper).to eq("achoo")
+        expect(config.min_hash_length).to eq(7)
+        expect(config.alphabet).to eq("XYZ")
+        expect(config.override_find).to eq(false)
+        expect(config.sign_hashids).to eq(false)
+      end
+
+      # default config does not change
+      config = Hashid::Rails.configuration
+      aggregate_failures "default config" do
+        expect(config.salt).to eq("")
+        expect(config.pepper).to eq("")
+        expect(config.min_hash_length).to eq(6)
+        expect(config.alphabet).to eq(
+          "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        )
+        expect(config.override_find).to eq(true)
+        expect(config.sign_hashids).to eq(true)
+      end
+    end
+
+    it "supports different configs for each model" do
+      Post.hashid_config(pepper: "achoo")
+      Comment.hashid_config(pepper: "gazoontite")
+
+      expect(FakeModel.hashid_configuration.pepper).to eq(FakeModel.table_name)
+      expect(Post.hashid_configuration.pepper).to eq("achoo")
+      expect(Comment.hashid_configuration.pepper).to eq("gazoontite")
     end
   end
 


### PR DESCRIPTION
This adds a `hashid_config` class method to allowing for overriding the default hashid config. The supports all the existing configuration options. It was added particularly to address the issue of changing a table name without changing the hashids.

Example usage:

```ruby
class MyModel < ApplicationRecord
  include Hashid::Rails
  hashid_config pepper: "old_table"
end
```