### PR TITLE
Allow configuring whether `to_param` is overridden

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -33,7 +33,10 @@ module Hashid
     def hashid
       self.class.encode_id(id)
     end
-    alias to_param hashid
+
+    def to_param
+      self.class.hashid_configuration.override_to_param ? hashid : super
+    end
 
     module ClassMethods
       def hashid_config(options = {})

--- a/lib/hashid/rails/configuration.rb
+++ b/lib/hashid/rails/configuration.rb
@@ -8,6 +8,7 @@ module Hashid
                     :min_hash_length,
                     :alphabet,
                     :override_find,
+                    :override_to_param,
                     :sign_hashids
 
       def initialize
@@ -18,6 +19,7 @@ module Hashid
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
                     "1234567890"
         @override_find = true
+        @override_to_param = true
         @sign_hashids = true
       end
 

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -20,7 +20,20 @@ describe Hashid::Rails do
   describe "#to_param" do
     it "aliases #hashid" do
       model = FakeModel.new(id: 100_117)
-      expect(model.hashid).to eq(model.to_param)
+      expect(model.to_param).to eq(model.hashid)
+    end
+
+    context "when override_to_param is false" do
+      before do
+        Hashid::Rails.configure do |config|
+          config.override_to_param = false
+        end
+      end
+
+      it "does not override to_param" do
+        model = FakeModel.new(id: 100_117)
+        expect(model.to_param).to eq(model.id.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
By default, hashid-rails overrides the `to_param` method on models to return a hashid. This lets `link_to` and other Rails helpers "just work." But there might be cases where you don't want this to happen, so now you can turn it off in the config globally or on a per-model basis.