### PR TITLE
Use ** splat operator to address deprecation warning in Ruby 2.7

### DIFF
--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -63,7 +63,7 @@ module Hashid
       def has_many(*args, &block)
         options = args.extract_options!
         options[:extend] = Array(options[:extend]).push(ClassMethods)
-        super(*args, options, &block)
+        super(*args, **options, &block)
       end
 
       def encode_id(ids)


### PR DESCRIPTION
Meant to address the following warning:

```
/Users/aford/code/hashid-rails/lib/hashid/rails.rb:66: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/aford/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.2/lib/active_record/associations.rb:1370: warning: The called method `has_many' is defined here
```