### PR TITLE
Use codeclimate-action to improve edge-case handling

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,19 +17,17 @@ jobs:
     - name: Install SQLite
       run: sudo apt install -y libsqlite3-dev
 
-    - name: Setup Code Climate test-reporter
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-
-    - name: Build and test with RSpec
+    - name: Install Ruby dependencies
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rspec
 
-    - name: Publish code coverage
-      run: |
-        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-        ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}
+    - name: Test with RSpec
+      run: bundle exec rspec
+
+    - name: Publish Test Coverage
+      uses: paambaati/codeclimate-action@v2.6.0
+      env:
+        CC_TEST_REPORTER_ID: 37aee70bb2e818f3bf4d2af88ea4a4355393901ba98b3876c244d42ed20fdbe1
+      with:
+        coverageCommand: true

--- a/hashid-rails.gemspec
+++ b/hashid-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "sqlite3"
 
   spec.add_runtime_dependency "activerecord", ">= 4.0"


### PR DESCRIPTION
Code Climate does not have an official GitHub action, but there are a
few tricky cases that need worked around making it undesirable to use
the shell scripts directly. What has caused the most headaches is the
absence of required ENV variables for branch and SHA that need
conditional handling depending on where the commit came from (commit,
pull request, fork, etc). By using a community plugin, the hope is to
simplify action config for this project and avoid these gotchas.

This also pins the version of SimpleCov to 0.17.x to fix an issue where
Code Climate's reporter does not current support versions >= 0.18
(https://github.com/paambaati/codeclimate-action/issues/102#issuecomment-586479859).