### PR TITLE
Remove pepper from config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ default options.
 Hashid::Rails.configure do |config|
   # The salt to use for generating hashid. Prepended with pepper (table name).
   config.salt = ""
-  config.pepper = table_name
 
   # The minimum length of generated hashids
   config.min_hash_length = 6


### PR DESCRIPTION
While waiting for #81 to be merged, let's remove the pepper, else it will trigger a `NameError: undefined local variable or method `table_name' for main:Object` when you create an initializer by copy-pasting the code from the README.